### PR TITLE
fix: replace rounded spinners with square Spinner component, remove rounded corners from status dots and skeletons

### DIFF
--- a/src/app/(dashboard)/clusters/[name]/agents/[agentName]/events/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/agents/[agentName]/events/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'next/navigation'
 import { useAgent } from '@/hooks/use-agents'
 import { ResourceEventsActivity } from '@/components/ui/events-activity'
 import { Card, CardContent } from '@/components/ui/card'
+import { Spinner } from '@/components/ui/spinner'
 
 export default function AgentEventsPage() {
   const params = useParams()
@@ -19,7 +20,7 @@ export default function AgentEventsPage() {
         <Card>
           <CardContent className="flex items-center justify-center py-16">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
+              <Spinner className="mx-auto mb-4" />
               <p className="text-gray-600">Loading events...</p>
             </div>
           </CardContent>

--- a/src/app/(dashboard)/clusters/[name]/agents/[agentName]/layout.tsx
+++ b/src/app/(dashboard)/clusters/[name]/agents/[agentName]/layout.tsx
@@ -20,6 +20,7 @@ import { cn } from '@/lib/utils'
 import { getStatusIcon, getStatusColor } from '@/components/agents/utils'
 import { DeleteResourceDialog } from '@/components/ui/delete-resource-dialog'
 import { toast } from 'sonner'
+import { Spinner } from '@/components/ui/spinner'
 
 function getCurrentTabValue(pathname: string, clusterName: string, agentName: string): string {
   // Check for organization-scoped paths and non-organization paths
@@ -250,7 +251,7 @@ export default function AgentDetailLayout({ children }: AgentDetailLayoutProps) 
           <div className="flex-1 min-h-0 flex flex-col">
             {yamlLoading ? (
               <div className="flex items-center justify-center py-8">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+                <Spinner size="sm" />
               </div>
             ) : (
               <div className="border rounded-lg flex-1 min-h-0 flex flex-col">

--- a/src/app/(dashboard)/clusters/[name]/agents/[agentName]/logs/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/agents/[agentName]/logs/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'next/navigation'
 import { useAgent } from '@/hooks/use-agents'
 import { AgentLogs } from '@/components/agents/agent-logs'
 import { Card, CardContent } from '@/components/ui/card'
+import { Spinner } from '@/components/ui/spinner'
 
 export default function AgentLogsPage() {
   const params = useParams()
@@ -19,7 +20,7 @@ export default function AgentLogsPage() {
         <Card>
           <CardContent className="flex items-center justify-center py-16">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
+              <Spinner className="mx-auto mb-4" />
               <p className="text-gray-600">Loading logs...</p>
             </div>
           </CardContent>

--- a/src/app/(dashboard)/clusters/[name]/agents/[agentName]/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/agents/[agentName]/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'next/navigation'
 import { useAgent } from '@/hooks/use-agents'
 import { AgentOverview } from '@/components/agents/agent-overview'
 import { Card, CardContent } from '@/components/ui/card'
+import { Spinner } from '@/components/ui/spinner'
 
 export default function AgentOverviewPage() {
   const params = useParams()
@@ -19,7 +20,7 @@ export default function AgentOverviewPage() {
         <Card>
           <CardContent className="flex items-center justify-center py-16">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
+              <Spinner className="mx-auto mb-4" />
               <p className="text-gray-600">Loading agent...</p>
             </div>
           </CardContent>

--- a/src/app/(dashboard)/clusters/[name]/agents/[agentName]/selfconfigs/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/agents/[agentName]/selfconfigs/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'next/navigation'
 import { useAgent } from '@/hooks/use-agents'
 import { AgentSelfConfigs } from '@/components/agents/agent-selfconfigs'
 import { Card, CardContent } from '@/components/ui/card'
+import { Spinner } from '@/components/ui/spinner'
 
 export default function AgentSelfConfigsPage() {
   const params = useParams()
@@ -19,7 +20,7 @@ export default function AgentSelfConfigsPage() {
         <Card>
           <CardContent className="flex items-center justify-center py-16">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4" />
+              <Spinner className="mx-auto mb-4" />
               <p className="text-gray-600">Loading self-configs...</p>
             </div>
           </CardContent>

--- a/src/app/(dashboard)/clusters/[name]/agents/[agentName]/workspace/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/agents/[agentName]/workspace/page.tsx
@@ -5,6 +5,7 @@ import { useAgent } from '@/hooks/use-agents'
 import { AgentWorkspace } from '@/components/workspace/agent-workspace'
 import { Card, CardContent } from '@/components/ui/card'
 import { FolderOpen } from 'lucide-react'
+import { Spinner } from '@/components/ui/spinner'
 
 export default function AgentWorkspacePage() {
   const params = useParams()
@@ -20,7 +21,7 @@ export default function AgentWorkspacePage() {
         <Card>
           <CardContent className="flex items-center justify-center py-16">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
+              <Spinner className="mx-auto mb-4" />
               <p className="text-gray-600">Loading workspace...</p>
             </div>
           </CardContent>

--- a/src/app/(dashboard)/clusters/[name]/models/[modelName]/details/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/models/[modelName]/details/page.tsx
@@ -5,6 +5,7 @@ import { useModel } from '@/hooks/use-models'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Shield } from 'lucide-react'
 import { LanguageModel } from '@/types/model'
+import { Spinner } from '@/components/ui/spinner'
 
 interface ModelDetailsProps {
   model: LanguageModel
@@ -78,7 +79,7 @@ export default function ModelDetailsPage() {
         <Card>
           <CardContent className="flex items-center justify-center py-16">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
+              <Spinner className="mx-auto mb-4" />
               <p className="text-gray-600">Loading model details...</p>
             </div>
           </CardContent>

--- a/src/app/(dashboard)/clusters/[name]/models/[modelName]/layout.tsx
+++ b/src/app/(dashboard)/clusters/[name]/models/[modelName]/layout.tsx
@@ -18,6 +18,7 @@ import { NotFound } from '@/components/ui/not-found'
 import { cn } from '@/lib/utils'
 import { DeleteResourceDialog } from '@/components/ui/delete-resource-dialog'
 import { toast } from 'sonner'
+import { Spinner } from '@/components/ui/spinner'
 
 function getCurrentTabValue(pathname: string, clusterName: string, modelName: string): string {
   // Check for organization-scoped paths and non-organization paths
@@ -257,7 +258,7 @@ export default function ModelDetailLayout({ children }: ModelDetailLayoutProps) 
           <div className="flex-1 min-h-0 flex flex-col">
             {yamlLoading ? (
               <div className="flex items-center justify-center py-8">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+                <Spinner size="sm" />
               </div>
             ) : (
               <div className="border rounded-lg flex-1 min-h-0 flex flex-col">

--- a/src/app/(dashboard)/clusters/[name]/models/[modelName]/logs/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/models/[modelName]/logs/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'next/navigation'
 import { useModel } from '@/hooks/use-models'
 import { ModelLogs } from '@/components/models/model-logs'
 import { Card, CardContent } from '@/components/ui/card'
+import { Spinner } from '@/components/ui/spinner'
 
 export default function ModelLogsPage() {
   const params = useParams()
@@ -19,7 +20,7 @@ export default function ModelLogsPage() {
         <Card>
           <CardContent className="flex items-center justify-center py-16">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
+              <Spinner className="mx-auto mb-4" />
               <p className="text-gray-600">Loading logs...</p>
             </div>
           </CardContent>

--- a/src/app/(dashboard)/clusters/[name]/models/[modelName]/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/models/[modelName]/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { ResourceEventsActivity } from '@/components/ui/events-activity'
 import { AlertCircle, CheckCircle, Clock } from 'lucide-react'
 import { LanguageModel } from '@/types/model'
+import { Spinner } from '@/components/ui/spinner'
 
 
 interface ModelOverviewProps {
@@ -127,7 +128,7 @@ export default function ModelOverviewPage() {
         <Card>
           <CardContent className="flex items-center justify-center py-16">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
+              <Spinner className="mx-auto mb-4" />
               <p className="text-gray-600">Loading model...</p>
             </div>
           </CardContent>

--- a/src/app/(dashboard)/clusters/[name]/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/page.tsx
@@ -124,12 +124,12 @@ export default function ClusterDashboard() {
                 <dd className="mt-1 flex items-center gap-2">
                   {cluster.status?.proxyReady === true ? (
                     <span className="inline-flex items-center gap-1 text-xs text-status-ready-foreground">
-                      <span className="h-2 w-2 rounded-full bg-accent inline-block" />
+                      <span className="h-2 w-2 bg-accent inline-block" />
                       Ready
                     </span>
                   ) : cluster.status?.proxyReady === false ? (
                     <span className="inline-flex items-center gap-1 text-xs text-status-pending-foreground">
-                      <span className="h-2 w-2 rounded-full bg-status-pending-foreground inline-block" />
+                      <span className="h-2 w-2 bg-status-pending-foreground inline-block" />
                       Not ready
                     </span>
                   ) : (

--- a/src/app/(dashboard)/clusters/[name]/personas/[personaName]/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/personas/[personaName]/page.tsx
@@ -24,6 +24,7 @@ import { DeleteResourceDialog } from '@/components/ui/delete-resource-dialog'
 import { toast } from 'sonner'
 import { AnimatedStatus } from '@/components/ui/animated-status'
 import { formatTimeAgo } from '@/lib/format'
+import { Spinner } from '@/components/ui/spinner'
 
 export default function ClusterPersonaDetailPage() {
   const router = useRouter()
@@ -262,7 +263,7 @@ export default function ClusterPersonaDetailPage() {
           <div className="flex-1 min-h-0 flex flex-col">
             {yamlLoading ? (
               <div className="flex items-center justify-center py-8">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+                <Spinner size="sm" />
               </div>
             ) : (
               <div className="border rounded-lg flex-1 min-h-0 flex flex-col">

--- a/src/app/(dashboard)/clusters/[name]/tools/[toolName]/layout.tsx
+++ b/src/app/(dashboard)/clusters/[name]/tools/[toolName]/layout.tsx
@@ -19,6 +19,7 @@ import { NotFound } from '@/components/ui/not-found'
 import { cn } from '@/lib/utils'
 import { DeleteResourceDialog } from '@/components/ui/delete-resource-dialog'
 import { toast } from 'sonner'
+import { Spinner } from '@/components/ui/spinner'
 
 function getCurrentTabValue(pathname: string, clusterName: string, toolName: string): string {
   const basePath = `/clusters/${clusterName}/tools/${toolName}`
@@ -236,7 +237,7 @@ export default function ToolDetailLayout({ children }: ToolDetailLayoutProps) {
           <div className="flex-1 min-h-0 flex flex-col">
             {yamlLoading ? (
               <div className="flex items-center justify-center py-8">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+                <Spinner size="sm" />
               </div>
             ) : (
               <div className="border rounded-lg flex-1 min-h-0 flex flex-col">

--- a/src/app/(dashboard)/clusters/[name]/tools/[toolName]/logs/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/tools/[toolName]/logs/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'next/navigation'
 import { useTool } from '@/hooks/use-tools'
 import { ToolLogs } from '@/components/tools/tool-logs'
 import { Card, CardContent } from '@/components/ui/card'
+import { Spinner } from '@/components/ui/spinner'
 
 export default function ToolLogsPage() {
   const params = useParams()
@@ -19,7 +20,7 @@ export default function ToolLogsPage() {
         <Card>
           <CardContent className="flex items-center justify-center py-16">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
+              <Spinner className="mx-auto mb-4" />
               <p className="text-gray-600">Loading logs...</p>
             </div>
           </CardContent>

--- a/src/app/(dashboard)/clusters/[name]/tools/[toolName]/network/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/tools/[toolName]/network/page.tsx
@@ -5,6 +5,7 @@ import { useTool } from '@/hooks/use-tools'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Globe } from 'lucide-react'
 import { NetworkEgressRule, NetworkPort } from '@/types/shared'
+import { Spinner } from '@/components/ui/spinner'
 
 export default function ToolNetworkPage() {
   const params = useParams()
@@ -20,7 +21,7 @@ export default function ToolNetworkPage() {
         <Card>
           <CardContent className="flex items-center justify-center py-16">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
+              <Spinner className="mx-auto mb-4" />
               <p className="text-gray-600">Loading network configuration...</p>
             </div>
           </CardContent>

--- a/src/app/(dashboard)/clusters/[name]/tools/install/[toolName]/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/tools/install/[toolName]/page.tsx
@@ -18,6 +18,7 @@ import { useEffect, useState } from 'react'
 import { ToolCatalogEntry, getToolDisplayName } from '@/types/tool-catalog'
 import { ResourceHeader } from '@/components/ui/resource-header'
 import { Wrench } from 'lucide-react'
+import { Spinner } from '@/components/ui/spinner'
 
 export default function InstallToolPage() {
   const params = useParams()
@@ -100,7 +101,7 @@ export default function InstallToolPage() {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-stone-900 dark:border-stone-100 mx-auto"></div>
+          <Spinner className="mx-auto" />
           <p className="mt-4 text-stone-600 dark:text-stone-400">Loading tool details...</p>
         </div>
       </div>

--- a/src/app/(dashboard)/clusters/[name]/tools/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/tools/page.tsx
@@ -14,6 +14,7 @@ import { LanguageTool } from '@/types/tool'
 import { EventsActivity } from '@/components/ui/events-activity'
 import { useTools } from '@/hooks/use-tools'
 import { useWatchTools } from '@/hooks/use-watch'
+import { Spinner } from '@/components/ui/spinner'
 
 export default function ClusterTools() {
   const params = useParams()
@@ -121,8 +122,8 @@ export default function ClusterTools() {
     return (
       <Card 
         className={`flex flex-col h-full ${
-          isInstalled && installedTool 
-            ? 'cursor-pointer hover:shadow-md hover:border-gray-300 transition-all' 
+          isInstalled && installedTool
+            ? 'cursor-pointer hover:shadow-md hover:border-border transition-all'
             : ''
         }`}
         onClick={handleCardClick}
@@ -245,7 +246,7 @@ export default function ClusterTools() {
     return (
         <div className="flex items-center justify-center min-h-[400px]">
           <div className="text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto"></div>
+            <Spinner className="mx-auto" />
             <p className="mt-4 text-gray-600">Loading tools...</p>
           </div>
         </div>

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -198,10 +198,10 @@ export default function OrganizationDashboard() {
                 {[1, 2, 3].map((i) => (
                   <div key={i} className="flex items-center justify-between">
                     <div className="flex items-center space-x-3">
-                      <div className="h-6 w-6 bg-muted rounded animate-pulse" />
-                      <div className="h-4 bg-muted rounded animate-pulse w-24" />
+                      <div className="h-6 w-6 bg-muted animate-pulse" />
+                      <div className="h-4 bg-muted animate-pulse w-24" />
                     </div>
-                    <div className="h-3 bg-muted/50 rounded animate-pulse w-16" />
+                    <div className="h-3 bg-muted/50 animate-pulse w-16" />
                   </div>
                 ))}
               </div>
@@ -282,10 +282,10 @@ export default function OrganizationDashboard() {
                 {[1, 2, 3].map((i) => (
                   <div key={i} className="flex items-center justify-between">
                     <div className="flex items-center space-x-3">
-                      <div className="h-6 w-6 bg-muted rounded animate-pulse" />
-                      <div className="h-4 bg-muted rounded animate-pulse w-24" />
+                      <div className="h-6 w-6 bg-muted animate-pulse" />
+                      <div className="h-4 bg-muted animate-pulse w-24" />
                     </div>
-                    <div className="h-3 bg-muted/50 rounded animate-pulse w-16" />
+                    <div className="h-3 bg-muted/50 animate-pulse w-16" />
                   </div>
                 ))}
               </div>

--- a/src/components/agents/agent-selfconfigs.tsx
+++ b/src/components/agents/agent-selfconfigs.tsx
@@ -14,6 +14,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { formatTimeAgo } from '@/components/agents/utils'
+import { Spinner } from '@/components/ui/spinner'
 
 function phaseBadgeClass(phase?: SelfConfigPhase): string {
   switch (phase) {
@@ -58,7 +59,7 @@ export function AgentSelfConfigs({ agent, clusterName }: AgentSelfConfigsProps) 
       <Card>
         <CardContent className="flex items-center justify-center py-16">
           <div className="text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-foreground mx-auto mb-4" />
+            <Spinner className="mx-auto mb-4" />
             <p className="text-muted-foreground">Loading self-configs...</p>
           </div>
         </CardContent>

--- a/src/components/tools/tool-logs.tsx
+++ b/src/components/tools/tool-logs.tsx
@@ -8,6 +8,7 @@ import { LanguageTool } from '@/types/tool'
 import { useLogViewer } from '@/hooks/useLogViewer'
 import { PodLogViewer } from '@/components/ui/pod-log-viewer'
 import { PodSelector, type PodInfo } from '@/components/ui/pod-selector'
+import { Spinner } from '@/components/ui/spinner'
 
 interface ToolLogsProps {
   tool: LanguageTool
@@ -130,7 +131,7 @@ export function ToolLogs({ tool, clusterName }: ToolLogsProps) {
         <Card>
           <CardContent className="flex items-center justify-center py-16">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
+              <Spinner className="mx-auto mb-4" />
               <p className="text-gray-600">Loading pods...</p>
             </div>
           </CardContent>

--- a/src/components/ui/pod-log-viewer.tsx
+++ b/src/components/ui/pod-log-viewer.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { AlertCircle, ChevronDown } from 'lucide-react'
 import { convertAnsiToHtml } from '../agents/utils'
 import type { UseLogViewerReturn } from '@/hooks/useLogViewer'
+import { Spinner } from '@/components/ui/spinner'
 
 interface PodLogViewerProps {
   logs: UseLogViewerReturn
@@ -116,7 +117,7 @@ export function PodLogViewer({
           >
             {logs.loading ? (
               <div className="flex items-center justify-center h-32 text-gray-500">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-500 mr-2"></div>
+                <Spinner size="sm" className="mr-2" />
                 Loading logs...
               </div>
             ) : logs.logs.length === 0 ? (

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils"
+
+interface SpinnerProps {
+  size?: "md" | "sm"
+  className?: string
+}
+
+export function Spinner({ size = "md", className }: SpinnerProps) {
+  return (
+    <div
+      className={cn(
+        "animate-spin border-b-2 border-foreground",
+        size === "md" ? "h-12 w-12" : "h-8 w-8",
+        className
+      )}
+    />
+  )
+}


### PR DESCRIPTION
Closes #19

## Summary
- Created `src/components/ui/spinner.tsx` — a square (no `rounded-*`) Spinner component with `size="md"` (h-12 w-12) and `size="sm"` (h-8 w-8), using `border-foreground` CSS var
- Replaced all 19 inline `animate-spin rounded-full ... border-gray-*` spinner divs across 16 files with `<Spinner>` or `<Spinner size="sm">`
- Removed `rounded-full` from status indicator dots in `clusters/[name]/page.tsx`
- Removed `rounded` from `animate-pulse` skeleton divs in the home dashboard `page.tsx`
- Fixed `hover:border-gray-300` → `hover:border-border` in tools list page

## Test plan
- [ ] All 46 tests pass (`npm test`)
- [ ] No inline spinners remain (`grep -rn "animate-spin rounded-full" src/`)
- [ ] No `border-gray-*` classes remain in src