### PR TITLE
fix: eliminate any types in API routes via extractItems/extractItem helpers

### DIFF
--- a/src/app/(dashboard)/clusters/[name]/agents/new/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/agents/new/page.tsx
@@ -289,15 +289,16 @@ export default function CreateClusterAgentPage() {
                             <div className="text-sm text-muted-foreground">Loading available tools...</div>
                           ) : (
                             <div className="grid grid-cols-2 gap-2 mt-2">
-                              {availableTools.map((tool: any) => (
-                                <div key={tool.metadata.name} className="flex items-center space-x-2">
+                              {availableTools.map((tool: LanguageTool) => (
+                                <div key={tool.metadata.name ?? ''} className="flex items-center space-x-2">
                                   <Checkbox
-                                    checked={field.value.includes(tool.metadata.name)}
+                                    checked={field.value.includes(tool.metadata.name ?? '')}
                                     onCheckedChange={(checked) => {
+                                      const toolName = tool.metadata.name ?? ''
                                       if (checked) {
-                                        field.onChange([...field.value, tool.metadata.name])
+                                        field.onChange([...field.value, toolName])
                                       } else {
-                                        field.onChange(field.value.filter(name => name !== tool.metadata.name))
+                                        field.onChange(field.value.filter(name => name !== toolName))
                                       }
                                     }}
                                   />

--- a/src/app/api/activity/recent/route.ts
+++ b/src/app/api/activity/recent/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUser } from '@/lib/user-context'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
+import type { CoreV1Event } from '@kubernetes/client-node'
 
 // GET /api/activity/recent - Get recent activity from Kubernetes events
 const NAMESPACE = process.env.OPERATOR_NAMESPACE || 'language-operator'
@@ -23,34 +24,31 @@ export async function GET(request: NextRequest) {
     })
 
     // Handle different response structures from k8s client
-    const allEvents = (eventsResponse as any)?.body?.items || 
-                     (eventsResponse as any)?.data?.items || 
-                     (eventsResponse as any)?.items || 
-                     []
+    const allEvents = extractItems<CoreV1Event>(eventsResponse)
 
     // Transform K8s events into activity format
     const activities = allEvents
-      .filter((event: any) => {
+      .filter((event: CoreV1Event) => {
         // Only show events related to Language Operator resources
         const involvedObject = event.involvedObject
         return involvedObject && 
                involvedObject.apiVersion === 'langop.io/v1alpha1' &&
-               ['LanguageAgent', 'LanguageModel', 'LanguageTool', 'LanguagePersona', 'LanguageCluster'].includes(involvedObject.kind)
+               ['LanguageAgent', 'LanguageModel', 'LanguageTool', 'LanguagePersona', 'LanguageCluster'].includes(involvedObject.kind ?? '')
       })
-      .sort((a: any, b: any) => {
+      .sort((a: CoreV1Event, b: CoreV1Event) => {
         // Sort by last timestamp (most recent first)
-        const aTime = new Date(a.lastTimestamp || a.firstTimestamp || a.metadata.creationTimestamp).getTime()
-        const bTime = new Date(b.lastTimestamp || b.firstTimestamp || b.metadata.creationTimestamp).getTime()
+        const aTime = new Date(a.lastTimestamp ?? a.firstTimestamp ?? a.metadata.creationTimestamp ?? 0).getTime()
+        const bTime = new Date(b.lastTimestamp ?? b.firstTimestamp ?? b.metadata.creationTimestamp ?? 0).getTime()
         return bTime - aTime
       })
       .slice(0, limit) // Apply final limit
-      .map((event: any) => {
+      .map((event: CoreV1Event) => {
         const involvedObject = event.involvedObject
-        const timestamp = event.lastTimestamp || event.firstTimestamp || event.metadata.creationTimestamp
-        
+        const timestamp = event.lastTimestamp ?? event.firstTimestamp ?? event.metadata.creationTimestamp ?? new Date(0)
+
         // Map K8s event to user-friendly activity
-        const resourceType = involvedObject.kind.replace('Language', '').toLowerCase()
-        const resourceName = involvedObject.name
+        const resourceType = (involvedObject.kind ?? '').replace('Language', '').toLowerCase()
+        const resourceName = involvedObject.name ?? ''
         const action = getActionFromEvent(event)
         const namespace = involvedObject.namespace || NAMESPACE
 
@@ -87,7 +85,7 @@ export async function GET(request: NextRequest) {
 }
 
 // Helper function to determine action from K8s event
-function getActionFromEvent(event: any): string {
+function getActionFromEvent(event: CoreV1Event): string {
   const reason = event.reason?.toLowerCase() || ''
   const type = event.type?.toLowerCase() || ''
   
@@ -105,7 +103,8 @@ function getActionFromEvent(event: any): string {
 }
 
 // Helper function to format activity messages
-function formatActivityMessage(resourceType: string, resourceName: string, action: string, event: any): string {
+function formatActivityMessage(resourceType: string, resourceName: string | undefined, action: string, _event: CoreV1Event): string {
+  if (!resourceName) resourceName = 'unknown'
   const capitalizedType = resourceType.charAt(0).toUpperCase() + resourceType.slice(1)
   
   switch (action) {

--- a/src/app/api/admin/registries/route.ts
+++ b/src/app/api/admin/registries/route.ts
@@ -27,14 +27,14 @@ export async function GET(request: NextRequest) {
       }))
 
       return NextResponse.json({ registries })
-    } catch (k8sError: any) {
+    } catch (k8sError) {
       console.error('Error reading ConfigMap:', k8sError)
-      
-      if (k8sError.statusCode === 404) {
+
+      if ((k8sError as { statusCode?: number }).statusCode === 404) {
         // ConfigMap doesn't exist, return empty list
         return NextResponse.json({ registries: [] })
       }
-      
+
       throw k8sError
     }
   } catch (error) {
@@ -75,20 +75,19 @@ export async function POST(request: NextRequest) {
     try {
       // Try to read existing ConfigMap first
       let configMapExists = true
-      let existingConfigMap: any
+      let existingConfigMap: Awaited<ReturnType<typeof client.readConfigMap>> | undefined
 
       try {
-        const response = await client.readConfigMap(OPERATOR_NAMESPACE, CONFIG_MAP_NAME)
-        existingConfigMap = response
-      } catch (error: any) {
-        if (error.statusCode === 404) {
+        existingConfigMap = await client.readConfigMap(OPERATOR_NAMESPACE, CONFIG_MAP_NAME)
+      } catch (error) {
+        if ((error as { statusCode?: number }).statusCode === 404) {
           configMapExists = false
         } else {
           throw error
         }
       }
 
-      if (configMapExists) {
+      if (configMapExists && existingConfigMap) {
         // Update existing ConfigMap
         const updatedConfigMap = {
           ...existingConfigMap,
@@ -124,7 +123,7 @@ export async function POST(request: NextRequest) {
         success: true, 
         message: 'Registry configuration updated successfully' 
       })
-    } catch (k8sError: any) {
+    } catch (k8sError) {
       console.error('Error updating ConfigMap:', k8sError)
       return NextResponse.json(
         { error: 'Failed to update registry configuration' },

--- a/src/app/api/clusters/[name]/access/route.ts
+++ b/src/app/api/clusters/[name]/access/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUser } from '@/lib/user-context'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import { createErrorResponse, validateClusterNameFormat } from '@/lib/api-error-handler'
+import * as k8s from '@kubernetes/client-node'
+import type { RbacV1Subject } from '@kubernetes/client-node'
 import { validateClusterExists } from '@/lib/cluster-validation'
 
 const NAMESPACE = process.env.OPERATOR_NAMESPACE || 'language-operator'
@@ -17,15 +19,15 @@ export async function GET(
     await validateClusterExists(NAMESPACE, clusterName)
 
     const response = await k8sClient.listRoleBindings(clusterName)
-    const items: any[] = (response as any)?.items ?? []
+    const items = extractItems<k8s.V1RoleBinding>(response)
 
     // Normalise to a stable shape for the UI
     const bindings = items
-      .filter((b: any) => ['langop-cluster-admin', 'langop-cluster-viewer'].includes(b.roleRef?.name))
-      .map((b: any) => ({
+      .filter((b: k8s.V1RoleBinding) => ['langop-cluster-admin', 'langop-cluster-viewer'].includes(b.roleRef?.name ?? ''))
+      .map((b: k8s.V1RoleBinding) => ({
         name: b.metadata?.name,
         role: b.roleRef?.name,
-        subjects: (b.subjects ?? []).map((s: any) => ({ kind: s.kind, name: s.name })),
+        subjects: (b.subjects ?? []).map((s: RbacV1Subject) => ({ kind: s.kind, name: s.name })),
         createdAt: b.metadata?.creationTimestamp,
       }))
 

--- a/src/app/api/clusters/[name]/agents/[agentName]/logs/route.ts
+++ b/src/app/api/clusters/[name]/agents/[agentName]/logs/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import { getAuthenticatedUser } from '@/lib/user-context'
+import type { V1Pod } from '@kubernetes/client-node'
 
 
 interface RouteParams {
@@ -26,16 +27,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     })
 
     // Handle different response structures from k8s client
-    let podList: any[] = []
-    if ((pods as any)?.body?.items) {
-      podList = (pods as any).body.items
-    } else if ((pods as any)?.data?.items) {
-      podList = (pods as any).data.items
-    } else if (Array.isArray(pods)) {
-      podList = pods
-    } else if ((pods as any)?.items) {
-      podList = (pods as any).items
-    }
+    const podList: V1Pod[] = extractItems<V1Pod>(pods)
 
     console.log(`Found ${podList.length} pods for agent ${agentName}`)
 
@@ -47,9 +39,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     // Select the appropriate pod
-    let pod
+    let pod: V1Pod | undefined
     if (podName) {
-      pod = podList.find(p => p.metadata.name === podName)
+      pod = podList.find(p => p.metadata?.name === podName)
       if (!pod) {
         return NextResponse.json({
           error: `Pod "${podName}" not found`,
@@ -58,24 +50,23 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       }
     } else {
       // Default behavior: get the most recent running pod, or most recent if none running
+      const getTime = (p: V1Pod) => new Date(p.metadata?.creationTimestamp ?? 0).getTime()
       const runningPods = podList.filter(p => p.status?.phase === 'Running')
       if (runningPods.length > 0) {
-        pod = runningPods.sort((a, b) =>
-          new Date(b.metadata.creationTimestamp).getTime() -
-          new Date(a.metadata.creationTimestamp).getTime()
-        )[0]
+        pod = runningPods.sort((a, b) => getTime(b) - getTime(a))[0]
       } else {
-        pod = podList.sort((a, b) =>
-          new Date(b.metadata.creationTimestamp).getTime() -
-          new Date(a.metadata.creationTimestamp).getTime()
-        )[0]
+        pod = podList.sort((a, b) => getTime(b) - getTime(a))[0]
       }
     }
 
-    console.log(`Getting logs from pod: ${pod.metadata.name}`)
+    if (!pod) {
+      return NextResponse.json({ logs: 'No pods found for this agent.', message: 'Agent has no pods' })
+    }
+
+    console.log(`Getting logs from pod: ${pod.metadata?.name}`)
 
     // Fetch logs from the pod
-    const logs = await k8sClient.getPodLogs(clusterName, pod.metadata.name, {
+    const logs = await k8sClient.getPodLogs(clusterName, pod.metadata?.name ?? '', {
       tailLines: 500,
       timestamps: true
     })
@@ -84,15 +75,15 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     let logContent = ''
     if (typeof logs === 'string') {
       logContent = logs
-    } else if ((logs as any)?.body) {
-      logContent = (logs as any).body
-    } else if ((logs as any)?.data) {
-      logContent = (logs as any).data
+    } else if ((logs as { body?: string })?.body) {
+      logContent = (logs as { body: string }).body
+    } else if ((logs as { data?: string })?.data) {
+      logContent = (logs as { data: string }).data
     }
 
     return NextResponse.json({
       logs: logContent || 'No logs available',
-      podName: pod.metadata.name,
+      podName: pod.metadata?.name,
       message: 'Logs retrieved successfully'
     })
 

--- a/src/app/api/clusters/[name]/agents/[agentName]/logs/stream/route.ts
+++ b/src/app/api/clusters/[name]/agents/[agentName]/logs/stream/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import { getAuthenticatedUser } from '@/lib/user-context'
+import type { V1Pod } from '@kubernetes/client-node'
 
 
 interface RouteParams {
@@ -26,44 +27,35 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     })
 
     // Handle different response structures from k8s client
-    let podList: any[] = []
-    if ((pods as any)?.body?.items) {
-      podList = (pods as any).body.items
-    } else if ((pods as any)?.data?.items) {
-      podList = (pods as any).data.items
-    } else if (Array.isArray(pods)) {
-      podList = pods
-    } else if ((pods as any)?.items) {
-      podList = (pods as any).items
-    }
+    const podList: V1Pod[] = extractItems<V1Pod>(pods)
 
     if (podList.length === 0) {
       return new Response('No pods found for this agent', { status: 404 })
     }
 
     // Select the appropriate pod
-    let pod
+    let pod: V1Pod | undefined
+    const getTime = (p: V1Pod) => new Date(p.metadata?.creationTimestamp ?? 0).getTime()
     if (podName) {
-      pod = podList.find(p => p.metadata.name === podName)
+      pod = podList.find(p => p.metadata?.name === podName)
       if (!pod) {
         return new Response(`Pod "${podName}" not found for agent ${agentName}`, { status: 404 })
       }
     } else {
       const runningPods = podList.filter(p => p.status?.phase === 'Running')
       if (runningPods.length > 0) {
-        pod = runningPods.sort((a, b) =>
-          new Date(b.metadata.creationTimestamp).getTime() -
-          new Date(a.metadata.creationTimestamp).getTime()
-        )[0]
+        pod = runningPods.sort((a, b) => getTime(b) - getTime(a))[0]
       } else {
-        pod = podList.sort((a, b) =>
-          new Date(b.metadata.creationTimestamp).getTime() -
-          new Date(a.metadata.creationTimestamp).getTime()
-        )[0]
+        pod = podList.sort((a, b) => getTime(b) - getTime(a))[0]
       }
     }
 
-    console.log(`Streaming logs from pod: ${pod.metadata.name}`)
+    if (!pod) {
+      return new Response('No pods found for this agent', { status: 404 })
+    }
+
+    const podMetaName = pod.metadata?.name ?? ''
+    console.log(`Streaming logs from pod: ${podMetaName}`)
 
     // Create a readable stream for Server-Sent Events
     const stream = new ReadableStream({
@@ -72,7 +64,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
         const streamLogs = async () => {
           try {
-            const logStream = await k8sClient.streamPodLogs(clusterName, pod.metadata.name, {
+            const logStream = await k8sClient.streamPodLogs(clusterName, podMetaName, {
               follow: true,
               timestamps: true,
               tailLines: 10
@@ -90,7 +82,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
             } else {
               const pollLogs = async () => {
                 try {
-                  const logs = await k8sClient.getPodLogs(clusterName, pod.metadata.name, {
+                  const logs = await k8sClient.getPodLogs(clusterName, podMetaName, {
                     tailLines: 1,
                     timestamps: true,
                     sinceSeconds: 1
@@ -99,10 +91,10 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
                   let logContent = ''
                   if (typeof logs === 'string') {
                     logContent = logs
-                  } else if ((logs as any)?.body) {
-                    logContent = (logs as any).body
-                  } else if ((logs as any)?.data) {
-                    logContent = (logs as any).data
+                  } else if ((logs as { body?: string })?.body) {
+                    logContent = (logs as { body: string }).body
+                  } else if ((logs as { data?: string })?.data) {
+                    logContent = (logs as { data: string }).data
                   }
 
                   if (logContent && logContent.trim()) {

--- a/src/app/api/clusters/[name]/agents/[agentName]/pods/route.ts
+++ b/src/app/api/clusters/[name]/agents/[agentName]/pods/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import { getAuthenticatedUser } from '@/lib/user-context'
+import type { V1Pod, V1ContainerStatus } from '@kubernetes/client-node'
 
 
 interface RouteParams {
@@ -24,32 +25,23 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     })
 
     // Handle different response structures from k8s client
-    let podList: any[] = []
-    if ((pods as any)?.body?.items) {
-      podList = (pods as any).body.items
-    } else if ((pods as any)?.data?.items) {
-      podList = (pods as any).data.items
-    } else if (Array.isArray(pods)) {
-      podList = pods
-    } else if ((pods as any)?.items) {
-      podList = (pods as any).items
-    }
+    const podList: V1Pod[] = extractItems<V1Pod>(pods)
 
     console.log(`Found ${podList.length} pods for agent ${agentName}`)
 
     // Transform pods into a more user-friendly format
-    const transformedPods = podList.map((pod) => {
+    const transformedPods = podList.map((pod: V1Pod) => {
       const status = pod.status?.phase || 'Unknown'
       const creationTimestamp = pod.metadata?.creationTimestamp
       const name = pod.metadata?.name || 'unknown'
-      
+
       // Determine if this is a running pod
       const isRunning = status === 'Running'
-      
+
       // Get container statuses for more detailed info
-      const containerStatuses = pod.status?.containerStatuses || []
-      const hasRunningContainers = containerStatuses.some((c: any) => c.state?.running)
-      
+      const containerStatuses: V1ContainerStatus[] = pod.status?.containerStatuses || []
+      const hasRunningContainers = containerStatuses.some((c: V1ContainerStatus) => c.state?.running)
+
       return {
         name,
         status,
@@ -58,13 +50,13 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         hasRunningContainers,
         // Additional metadata that might be useful
         labels: pod.metadata?.labels || {},
-        restartCount: containerStatuses.reduce((sum: number, c: any) => sum + (c.restartCount || 0), 0),
+        restartCount: containerStatuses.reduce((sum: number, c: V1ContainerStatus) => sum + (c.restartCount || 0), 0),
       }
     })
 
     // Sort pods by creation timestamp (newest first)
-    const sortedPods = transformedPods.sort((a, b) => 
-      new Date(b.creationTimestamp).getTime() - new Date(a.creationTimestamp).getTime()
+    const sortedPods = transformedPods.sort((a, b) =>
+      new Date(b.creationTimestamp ?? 0).getTime() - new Date(a.creationTimestamp ?? 0).getTime()
     )
 
     // Determine the recommended pod (first running pod, or most recent if none running)

--- a/src/app/api/clusters/[name]/agents/[agentName]/route.ts
+++ b/src/app/api/clusters/[name]/agents/[agentName]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItem } from '@/lib/k8s-client'
 import { getAuthenticatedUser } from '@/lib/user-context'
-import { LanguageAgent, LanguageAgentFormData } from '@/types/agent'
+import { LanguageAgent, LanguageAgentFormData, LanguageAgentSpec } from '@/types/agent'
 
 
 // GET /api/clusters/[name]/agents/[agentName] - Get specific agent details
@@ -22,15 +22,7 @@ export async function GET(
 
     try {
       const response = await k8sClient.getLanguageAgent(clusterName, agentName)
-
-      // Handle different response structures from k8s client
-      if ((response as any)?.body) {
-        agent = (response as any).body
-      } else if ((response as any)?.data) {
-        agent = (response as any).data
-      } else if (response) {
-        agent = response as LanguageAgent
-      }
+      agent = extractItem<LanguageAgent>(response)
     } catch (k8sError) {
       if (k8sError instanceof Error && k8sError.message.includes('404')) {
         return NextResponse.json({
@@ -84,14 +76,7 @@ export async function PATCH(
     let currentAgent: LanguageAgent | null = null
     try {
       const response = await k8sClient.getLanguageAgent(clusterName, agentName)
-
-      if ((response as any)?.body) {
-        currentAgent = (response as any).body
-      } else if ((response as any)?.data) {
-        currentAgent = (response as any).data
-      } else if (response) {
-        currentAgent = response as LanguageAgent
-      }
+      currentAgent = extractItem<LanguageAgent>(response)
     } catch (k8sError) {
       if (k8sError instanceof Error && k8sError.message.includes('404')) {
         return NextResponse.json({
@@ -110,7 +95,7 @@ export async function PATCH(
     }
 
     // Build the updated agent spec
-    const updatedSpec: any = { ...currentAgent.spec }
+    const updatedSpec: LanguageAgentSpec = { ...currentAgent.spec }
 
     // Update basic fields
     if (body.instructions !== undefined) {

--- a/src/app/api/clusters/[name]/agents/[agentName]/selfconfigs/route.ts
+++ b/src/app/api/clusters/[name]/agents/[agentName]/selfconfigs/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import { getAuthenticatedUser } from '@/lib/user-context'
+import { LanguageAgentSelfConfig } from '@/types/selfconfig'
 
 interface RouteParams {
   params: Promise<{ name: string; agentName: string }>
@@ -20,15 +21,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       )
     }
 
-    let allItems: any[] = []
+    let allItems: LanguageAgentSelfConfig[] = []
 
     try {
       const response = await k8sClient.listLanguageAgentSelfConfigs(clusterName)
-      allItems =
-        (response as any)?.body?.items ??
-        (response as any)?.data?.items ??
-        (response as any)?.items ??
-        []
+      allItems = extractItems<LanguageAgentSelfConfig>(response)
     } catch (k8sError) {
       console.error(
         'Error fetching self-configs from Kubernetes:',
@@ -40,7 +37,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     // Scope to the requesting agent
     const items = allItems.filter(
-      (item: any) => item?.spec?.instanceRef === agentName
+      (item: LanguageAgentSelfConfig) => item?.spec?.instanceRef === agentName
     )
 
     return NextResponse.json({ success: true, data: items })

--- a/src/app/api/clusters/[name]/agents/[agentName]/workspace/files/download/route.ts
+++ b/src/app/api/clusters/[name]/agents/[agentName]/workspace/files/download/route.ts
@@ -43,7 +43,7 @@ export async function GET(
           'Content-Length': fileBuffer.length.toString(),
         },
       })
-    } catch (error: any) {
+    } catch (error) {
       if (error instanceof WorkspaceError) {
         const statusCode = getStatusCodeForWorkspaceError(error.code)
         return NextResponse.json({ 
@@ -56,7 +56,7 @@ export async function GET(
       console.error('Workspace download error:', error)
       return NextResponse.json({ error: 'Failed to download file' }, { status: 500 })
     }
-  } catch (error: any) {
+  } catch (error) {
     console.error('Workspace download API error:', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/clusters/[name]/agents/[agentName]/workspace/files/route.ts
+++ b/src/app/api/clusters/[name]/agents/[agentName]/workspace/files/route.ts
@@ -24,7 +24,7 @@ export async function GET(
       )
       
       return NextResponse.json(result)
-    } catch (error: any) {
+    } catch (error) {
       if (error instanceof WorkspaceError) {
         const statusCode = getStatusCodeForWorkspaceError(error.code)
         return NextResponse.json({ 
@@ -37,7 +37,7 @@ export async function GET(
       console.error('Workspace list error:', error)
       return NextResponse.json({ error: 'Failed to list workspace files' }, { status: 500 })
     }
-  } catch (error: any) {
+  } catch (error) {
     console.error('Workspace API error:', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
@@ -79,7 +79,7 @@ export async function POST(
         path: filePath,
         size: fileBuffer.length
       })
-    } catch (error: any) {
+    } catch (error) {
       if (error instanceof WorkspaceError) {
         const statusCode = getStatusCodeForWorkspaceError(error.code)
         return NextResponse.json({ 
@@ -92,7 +92,7 @@ export async function POST(
       console.error('Workspace upload error:', error)
       return NextResponse.json({ error: 'Failed to upload file' }, { status: 500 })
     }
-  } catch (error: any) {
+  } catch (error) {
     console.error('Workspace upload API error:', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
@@ -125,7 +125,7 @@ export async function DELETE(
         message: 'File deleted successfully',
         path 
       })
-    } catch (error: any) {
+    } catch (error) {
       if (error instanceof WorkspaceError) {
         const statusCode = getStatusCodeForWorkspaceError(error.code)
         return NextResponse.json({ 
@@ -138,7 +138,7 @@ export async function DELETE(
       console.error('Workspace delete error:', error)
       return NextResponse.json({ error: 'Failed to delete file' }, { status: 500 })
     }
-  } catch (error: any) {
+  } catch (error) {
     console.error('Workspace delete API error:', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/clusters/[name]/agents/[agentName]/workspace/files/view/route.ts
+++ b/src/app/api/clusters/[name]/agents/[agentName]/workspace/files/view/route.ts
@@ -67,7 +67,7 @@ export async function GET(
         mimeType,
         isViewable: true,
       })
-    } catch (error: any) {
+    } catch (error) {
       if (error instanceof WorkspaceError) {
         const statusCode = getStatusCodeForWorkspaceError(error.code)
         return NextResponse.json({ 
@@ -80,7 +80,7 @@ export async function GET(
       console.error('Workspace view error:', error)
       return NextResponse.json({ error: 'Failed to view file' }, { status: 500 })
     }
-  } catch (error: any) {
+  } catch (error) {
     console.error('Workspace view API error:', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/clusters/[name]/agents/[agentName]/yaml/route.ts
+++ b/src/app/api/clusters/[name]/agents/[agentName]/yaml/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItem } from '@/lib/k8s-client'
 import { getAuthenticatedUser } from '@/lib/user-context'
+import { LanguageAgent } from '@/types/agent'
 import yaml from 'js-yaml'
 
 
@@ -18,19 +19,11 @@ export async function GET(
     }
 
     // Fetch specific agent from namespace
-    let agent: any = null
+    let agent: LanguageAgent | null = null
 
     try {
       const response = await k8sClient.getLanguageAgent(clusterName, agentName)
-
-      // Handle different response structures from k8s client
-      if ((response as any)?.body) {
-        agent = (response as any).body
-      } else if ((response as any)?.data) {
-        agent = (response as any).data
-      } else if (response) {
-        agent = response as any
-      }
+      agent = extractItem<LanguageAgent>(response)
     } catch (k8sError) {
       if (k8sError instanceof Error && k8sError.message.includes('404')) {
         return NextResponse.json({

--- a/src/app/api/clusters/[name]/agents/route.ts
+++ b/src/app/api/clusters/[name]/agents/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import { getAuthenticatedUser } from '@/lib/user-context'
 import { filterByClusterRef } from '@/lib/cluster-utils'
 import { validateClusterForResourceCreation, validateClusterExists, validateResourceBelongsToCluster } from '@/lib/cluster-validation'
@@ -30,8 +30,8 @@ export async function GET(
     const queryParams: LanguageAgentListParams = {
       page: parseInt(url.searchParams.get('page') || '1'),
       limit: parseInt(url.searchParams.get('limit') || '50'),
-      sortBy: (url.searchParams.get('sortBy') as any) || 'name',
-      sortOrder: (url.searchParams.get('sortOrder') as any) || 'asc',
+      sortBy: (url.searchParams.get('sortBy') as LanguageAgentListParams['sortBy']) || 'name',
+      sortOrder: (url.searchParams.get('sortOrder') as LanguageAgentListParams['sortOrder']) || 'asc',
       search: url.searchParams.get('search') || undefined,
       phase: url.searchParams.getAll('phase') || undefined,
     }
@@ -43,7 +43,7 @@ export async function GET(
     )
 
     // Handle different response structures from k8s client
-    const allAgents = (response as any)?.items || (response.data as any)?.items || (response.body as any)?.items || []
+    const allAgents = extractItems<LanguageAgent>(response)
 
     // Filter agents to only show those that belong to this specific cluster
     const clusterAgents = validateResourceBelongsToCluster(

--- a/src/app/api/clusters/[name]/models/[modelName]/logs/route.ts
+++ b/src/app/api/clusters/[name]/models/[modelName]/logs/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUser } from '@/lib/user-context'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import type { V1Pod } from '@kubernetes/client-node'
 
 interface RouteParams {
@@ -28,16 +28,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     })
 
     // Handle different response structures from k8s client
-    let podList: V1Pod[] = []
-    if ((pods as any)?.body?.items) {
-      podList = (pods as any).body.items
-    } else if ((pods as any)?.data?.items) {
-      podList = (pods as any).data.items
-    } else if (Array.isArray(pods)) {
-      podList = pods
-    } else if ((pods as any)?.items) {
-      podList = (pods as any).items
-    }
+    const podList: V1Pod[] = extractItems<V1Pod>(pods)
 
     console.log(`Found ${podList.length} proxy pod(s) for cluster ${clusterName}`)
 

--- a/src/app/api/clusters/[name]/models/[modelName]/pods/route.ts
+++ b/src/app/api/clusters/[name]/models/[modelName]/pods/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUser } from '@/lib/user-context'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import type { V1Pod } from '@kubernetes/client-node'
 
 interface RouteParams {
@@ -26,16 +26,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     })
 
     // Handle different response structures from k8s client
-    let podList: V1Pod[] = []
-    if ((pods as any)?.body?.items) {
-      podList = (pods as any).body.items
-    } else if ((pods as any)?.data?.items) {
-      podList = (pods as any).data.items
-    } else if (Array.isArray(pods)) {
-      podList = pods
-    } else if ((pods as any)?.items) {
-      podList = (pods as any).items
-    }
+    const podList: V1Pod[] = extractItems<V1Pod>(pods)
 
     console.log(`Found ${podList.length} proxy pod(s) for cluster ${clusterName}`)
 

--- a/src/app/api/clusters/[name]/models/[modelName]/route.ts
+++ b/src/app/api/clusters/[name]/models/[modelName]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server'
 import { getAuthenticatedUser } from '@/lib/user-context'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItem } from '@/lib/k8s-client'
 import { validateClusterExists } from '@/lib/cluster-validation'
 import {
   createErrorResponse,
@@ -9,6 +9,7 @@ import {
   validateClusterNameFormat,
 } from '@/lib/api-error-handler'
 import { z } from 'zod'
+import { LanguageModel } from '@/types/model'
 
 // Validation schema — mirrors the 6-field LanguageModelSpec CRD exactly
 const updateModelSchema = z.object({
@@ -42,14 +43,7 @@ export async function GET(
       k8sClient.getLanguageModel(clusterName, modelName)
     )
 
-    let model = null
-    if (response.body && typeof response.body === 'object') {
-      model = response.body
-    } else if (response.data && typeof response.data === 'object') {
-      model = response.data
-    } else {
-      model = response
-    }
+    const model = extractItem<LanguageModel>(response)
 
     if (!model) {
       return createErrorResponse(
@@ -87,14 +81,7 @@ export async function PUT(
       k8sClient.getLanguageModel(clusterName, modelName)
     )
 
-    let existingModel: any = null
-    if (existingResponse.body && typeof existingResponse.body === 'object') {
-      existingModel = existingResponse.body
-    } else if (existingResponse.data && typeof existingResponse.data === 'object') {
-      existingModel = existingResponse.data
-    } else {
-      existingModel = existingResponse
-    }
+    const existingModel = extractItem<LanguageModel>(existingResponse)
 
     if (!existingModel) {
       return createErrorResponse(

--- a/src/app/api/clusters/[name]/models/[modelName]/yaml/route.ts
+++ b/src/app/api/clusters/[name]/models/[modelName]/yaml/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUser } from '@/lib/user-context'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItem } from '@/lib/k8s-client'
+import { LanguageModel } from '@/types/model'
 import yaml from 'js-yaml'
 
 // GET /api/clusters/[name]/models/[modelName]/yaml - Get model YAML
@@ -20,19 +21,11 @@ export async function GET(
     }
 
     // Fetch specific model from organization namespace
-    let model: any = null
-    
+    let model: LanguageModel | null = null
+
     try {
       const response = await k8sClient.getLanguageModel(clusterName, modelName)
-      
-      // Handle different response structures from k8s client
-      if ((response as any)?.body) {
-        model = (response as any).body
-      } else if ((response as any)?.data) {
-        model = (response as any).data
-      } else if (response) {
-        model = response as any
-      }
+      model = extractItem<LanguageModel>(response)
     } catch (k8sError) {
       // If model not found, return 404
       if (k8sError instanceof Error && k8sError.message.includes('404')) {

--- a/src/app/api/clusters/[name]/models/__tests__/route.test.ts
+++ b/src/app/api/clusters/[name]/models/__tests__/route.test.ts
@@ -32,6 +32,22 @@ jest.mock('@/lib/k8s-client', () => ({
     listLanguageModels: jest.fn(),
     createLanguageModel: jest.fn(),
   },
+  extractItems: (response: unknown) => {
+    const r = response as Record<string, unknown>
+    return (
+      ((r?.body as Record<string, unknown>)?.items as unknown[]) ??
+      ((r?.data as Record<string, unknown>)?.items as unknown[]) ??
+      (r?.items as unknown[]) ??
+      []
+    )
+  },
+  extractItem: (response: unknown) => {
+    const r = response as Record<string, unknown>
+    if (r?.body) return r.body
+    if (r?.data) return r.data
+    if (r) return r
+    return null
+  },
 }))
 
 jest.mock('@/lib/cluster-validation', () => ({

--- a/src/app/api/clusters/[name]/models/route.ts
+++ b/src/app/api/clusters/[name]/models/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUser } from '@/lib/user-context'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import { filterByClusterRef } from '@/lib/cluster-utils'
 import { validateClusterExists, validateResourceBelongsToCluster } from '@/lib/cluster-validation'
 import { createErrorResponse, createSuccessResponse, handleKubernetesOperation, validateClusterNameFormat, createAuthenticationRequiredError, createPermissionDeniedError, KubernetesError } from '@/lib/api-error-handler'
@@ -34,8 +34,8 @@ export async function GET(
       namespace: clusterName,
       page: parseInt(url.searchParams.get('page') || '1'),
       limit: parseInt(url.searchParams.get('limit') || '50'),
-      sortBy: (url.searchParams.get('sortBy') as any) || 'name',
-      sortOrder: (url.searchParams.get('sortOrder') as any) || 'asc',
+      sortBy: (url.searchParams.get('sortBy') as LanguageModelListParams['sortBy']) || 'name',
+      sortOrder: (url.searchParams.get('sortOrder') as LanguageModelListParams['sortOrder']) || 'asc',
       search: url.searchParams.get('search') || undefined,
       provider: url.searchParams.getAll('provider') || undefined,
       phase: url.searchParams.getAll('phase') || undefined,
@@ -50,20 +50,7 @@ export async function GET(
     )
     
     // Handle different response structures
-    let rawItems = null
-    if (response.body && typeof response.body === 'object') {
-      rawItems = (response.body as any)?.items
-    } else if (response.data && typeof response.data === 'object') {
-      rawItems = (response.data as any)?.items
-    } else {
-      if (Array.isArray(response)) {
-        rawItems = response
-      } else if ((response as any)?.items) {
-        rawItems = (response as any).items
-      }
-    }
-    
-    const allModels = rawItems || []
+    const allModels = extractItems<LanguageModel>(response)
     
     // Filter models that belong to this specific cluster
     // Uses validation to handle orphaned resources gracefully
@@ -107,8 +94,8 @@ export async function GET(
 
     // Sort models
     filteredModels.sort((a: LanguageModel, b: LanguageModel) => {
-      let aValue: any, bValue: any
-      
+      let aValue: string | number, bValue: string | number
+
       switch (listParams.sortBy) {
         case 'name':
           aValue = a.metadata.name || ''

--- a/src/app/api/clusters/[name]/personas/[personaName]/route.ts
+++ b/src/app/api/clusters/[name]/personas/[personaName]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUser } from '@/lib/user-context'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItem } from '@/lib/k8s-client'
 import { validateClusterExists } from '@/lib/cluster-validation'
 import {
   createErrorResponse,
@@ -8,6 +8,7 @@ import {
   handleKubernetesOperation,
   validateClusterNameFormat,
 } from '@/lib/api-error-handler'
+import { LanguagePersona } from '@/types/persona'
 
 // GET /api/clusters/[name]/personas/[personaName] - Get a specific persona in a cluster
 const NAMESPACE = process.env.OPERATOR_NAMESPACE || 'language-operator'
@@ -30,14 +31,7 @@ export async function GET(
       k8sClient.getLanguagePersona(clusterName, personaName)
     )
 
-    let persona = null
-    if (response.body && typeof response.body === 'object') {
-      persona = response.body
-    } else if (response.data && typeof response.data === 'object') {
-      persona = response.data
-    } else {
-      persona = response
-    }
+    const persona = extractItem<LanguagePersona>(response)
 
     if (!persona) {
       return createErrorResponse(
@@ -77,14 +71,7 @@ export async function PATCH(
       k8sClient.getLanguagePersona(clusterName, personaName)
     )
 
-    let existingPersona = null
-    if (existingResponse.body && typeof existingResponse.body === 'object') {
-      existingPersona = existingResponse.body
-    } else if (existingResponse.data && typeof existingResponse.data === 'object') {
-      existingPersona = existingResponse.data
-    } else {
-      existingPersona = existingResponse
-    }
+    const existingPersona = extractItem<LanguagePersona>(existingResponse)
 
     if (!existingPersona) {
       return createErrorResponse(

--- a/src/app/api/clusters/[name]/personas/__tests__/route.test.ts
+++ b/src/app/api/clusters/[name]/personas/__tests__/route.test.ts
@@ -37,6 +37,22 @@ jest.mock('@/lib/k8s-client', () => ({
     listLanguagePersonas: jest.fn(),
     createLanguagePersona: jest.fn(),
   },
+  extractItems: (response: unknown) => {
+    const r = response as Record<string, unknown>
+    return (
+      ((r?.body as Record<string, unknown>)?.items as unknown[]) ??
+      ((r?.data as Record<string, unknown>)?.items as unknown[]) ??
+      (r?.items as unknown[]) ??
+      []
+    )
+  },
+  extractItem: (response: unknown) => {
+    const r = response as Record<string, unknown>
+    if (r?.body) return r.body
+    if (r?.data) return r.data
+    if (r) return r
+    return null
+  },
 }))
 
 // Validation mocks: let the route proceed to k8s without hitting the cluster

--- a/src/app/api/clusters/[name]/personas/route.ts
+++ b/src/app/api/clusters/[name]/personas/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUser } from '@/lib/user-context'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import { filterByClusterRef } from '@/lib/cluster-utils'
 import { validateClusterForResourceCreation, validateClusterExists, validateResourceBelongsToCluster } from '@/lib/cluster-validation'
 import { createErrorResponse, createSuccessResponse, handleKubernetesOperation, validateClusterNameFormat, ApiError, createAuthenticationRequiredError, createPermissionDeniedError } from '@/lib/api-error-handler'
@@ -32,8 +32,8 @@ export async function GET(
     const queryParams: LanguagePersonaListParams = {
       page: parseInt(url.searchParams.get('page') || '1'),
       limit: parseInt(url.searchParams.get('limit') || '50'),
-      sortBy: (url.searchParams.get('sortBy') as any) || 'name',
-      sortOrder: (url.searchParams.get('sortOrder') as any) || 'asc',
+      sortBy: (url.searchParams.get('sortBy') as LanguagePersonaListParams['sortBy']) || 'name',
+      sortOrder: (url.searchParams.get('sortOrder') as LanguagePersonaListParams['sortOrder']) || 'asc',
       search: url.searchParams.get('search') || undefined,
       tone: url.searchParams.getAll('tone') || undefined,
       phase: url.searchParams.getAll('phase') || undefined,
@@ -46,7 +46,7 @@ export async function GET(
     )
     
     // Handle different response structures from k8s client
-    const allPersonas = (response as any)?.items || (response.data as any)?.items || (response.body as any)?.items || []
+    const allPersonas = extractItems<LanguagePersona>(response)
 
     // Filter personas to only show those that belong to this specific cluster
     // Uses validation to handle orphaned resources gracefully

--- a/src/app/api/clusters/[name]/tools/[toolName]/pods/route.ts
+++ b/src/app/api/clusters/[name]/tools/[toolName]/pods/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItem, extractItems } from '@/lib/k8s-client'
 import { getAuthenticatedUser } from '@/lib/user-context'
+import type { V1Pod, V1Container, V1ContainerStatus } from '@kubernetes/client-node'
+import { LanguageTool } from '@/types/tool'
 
 interface RouteParams {
   params: Promise<{
@@ -20,15 +22,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     // First, get the tool to understand its deployment mode
     const toolResource = await k8sClient.getLanguageTool(clusterName, toolName)
-    
-    let toolData: any
-    if ((toolResource as any)?.body) {
-      toolData = (toolResource as any).body
-    } else if ((toolResource as any)?.data) {
-      toolData = (toolResource as any).data
-    } else {
-      toolData = toolResource
-    }
+    const toolData = extractItem<LanguageTool>(toolResource)
 
     if (!toolData) {
       return NextResponse.json({ error: 'Tool not found' }, { status: 404 })
@@ -36,7 +30,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     const deploymentMode = toolData.spec?.deploymentMode || 'service'
 
-    let pods: any[] = []
     let labelSelector = ''
     let podType = ''
 
@@ -58,53 +51,44 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     })
 
     // Handle different response structures from k8s client
-    let podList: any[] = []
-    if ((podsResponse as any)?.body?.items) {
-      podList = (podsResponse as any).body.items
-    } else if ((podsResponse as any)?.data?.items) {
-      podList = (podsResponse as any).data.items
-    } else if (Array.isArray(podsResponse)) {
-      podList = podsResponse
-    } else if ((podsResponse as any)?.items) {
-      podList = (podsResponse as any).items
-    }
+    const podList: V1Pod[] = extractItems<V1Pod>(podsResponse)
 
     console.log(`Found ${podList.length} ${podType} pods for tool ${toolName}`)
 
     // Transform pods into a more user-friendly format
-    const transformedPods = podList.map((pod) => {
+    const transformedPods = podList.map((pod: V1Pod) => {
       const status = pod.status?.phase || 'Unknown'
       const creationTimestamp = pod.metadata?.creationTimestamp
       const name = pod.metadata?.name || 'unknown'
-      
+
       // Determine if this is a running pod
       const isRunning = status === 'Running'
-      
+
       // Get container statuses for more detailed info
-      const containerStatuses = pod.status?.containerStatuses || []
-      const hasRunningContainers = containerStatuses.some((c: any) => c.state?.running)
-      
+      const containerStatuses: V1ContainerStatus[] = pod.status?.containerStatuses || []
+      const hasRunningContainers = containerStatuses.some((c: V1ContainerStatus) => c.state?.running)
+
       // For sidecar mode, check if this pod actually uses the tool
       let hasToolContainer = true
       if (deploymentMode === 'sidecar') {
         // Check if this agent pod has the tool as a sidecar container or init container
-        const containers = pod.spec?.containers || []
-        const initContainers = pod.spec?.initContainers || []
-        hasToolContainer = [...containers, ...initContainers].some((c: any) => 
+        const containers: V1Container[] = pod.spec?.containers || []
+        const initContainers: V1Container[] = pod.spec?.initContainers || []
+        hasToolContainer = [...containers, ...initContainers].some((c: V1Container) =>
           c.name?.includes(toolName) || c.image?.includes(toolName)
         )
       }
-      
+
       // Get available containers for log viewing (including init containers)
-      const containers = pod.spec?.containers || []
-      const initContainers = pod.spec?.initContainers || []
+      const containers: V1Container[] = pod.spec?.containers || []
+      const initContainers: V1Container[] = pod.spec?.initContainers || []
       const allContainers = [...containers, ...initContainers]
-      const availableContainers = allContainers.map((c: any) => ({
+      const availableContainers = allContainers.map((c: V1Container) => ({
         name: c.name,
         image: c.image,
-        isToolContainer: deploymentMode === 'sidecar' ? 
-          (c.name?.includes(toolName) || c.image?.includes(toolName)) : 
-          c.name === toolName || c.name === 'tool'
+        isToolContainer: deploymentMode === 'sidecar'
+          ? (c.name?.includes(toolName) || c.image?.includes(toolName))
+          : c.name === toolName || c.name === 'tool',
       }))
 
       return {
@@ -119,7 +103,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         availableContainers,
         // Additional metadata that might be useful
         labels: pod.metadata?.labels || {},
-        restartCount: containerStatuses.reduce((sum: number, c: any) => sum + (c.restartCount || 0), 0),
+        restartCount: containerStatuses.reduce((sum: number, c: V1ContainerStatus) => sum + (c.restartCount || 0), 0),
       }
     })
 
@@ -129,8 +113,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       transformedPods
 
     // Sort pods by creation timestamp (newest first)
-    const sortedPods = relevantPods.sort((a, b) => 
-      new Date(b.creationTimestamp).getTime() - new Date(a.creationTimestamp).getTime()
+    const sortedPods = relevantPods.sort((a, b) =>
+      new Date(b.creationTimestamp ?? 0).getTime() - new Date(a.creationTimestamp ?? 0).getTime()
     )
 
     // Determine the recommended pod (first running pod, or most recent if none running)
@@ -141,7 +125,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     let recommendedContainer = null
     if (recommendedPod && recommendedPod.availableContainers.length > 0) {
       // Prefer tool containers first, then any container
-      const toolContainers = recommendedPod.availableContainers.filter((c: any) => c.isToolContainer)
+      const toolContainers = recommendedPod.availableContainers.filter(c => c.isToolContainer)
       recommendedContainer = toolContainers.length > 0 ? 
         toolContainers[0].name : 
         recommendedPod.availableContainers[0].name

--- a/src/app/api/clusters/[name]/tools/route.ts
+++ b/src/app/api/clusters/[name]/tools/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUser } from '@/lib/user-context'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import { filterByClusterRef } from '@/lib/cluster-utils'
 import { validateClusterExists, validateResourceBelongsToCluster, validateClusterForResourceCreation } from '@/lib/cluster-validation'
 import { createErrorResponse, createSuccessResponse, handleKubernetesOperation, validateClusterNameFormat, createAuthenticationRequiredError, createPermissionDeniedError } from '@/lib/api-error-handler'
@@ -31,8 +31,8 @@ export async function GET(
     const queryParams: LanguageToolListParams = {
       page: parseInt(url.searchParams.get('page') || '1'),
       limit: parseInt(url.searchParams.get('limit') || '50'),
-      sortBy: (url.searchParams.get('sortBy') as any) || 'name',
-      sortOrder: (url.searchParams.get('sortOrder') as any) || 'asc',
+      sortBy: (url.searchParams.get('sortBy') as LanguageToolListParams['sortBy']) || 'name',
+      sortOrder: (url.searchParams.get('sortOrder') as LanguageToolListParams['sortOrder']) || 'asc',
       search: url.searchParams.get('search') || undefined,
       type: url.searchParams.getAll('type') || undefined,
       phase: url.searchParams.getAll('phase') || undefined,
@@ -45,7 +45,7 @@ export async function GET(
     )
     
     // Handle different response structures from k8s client
-    const allTools = (response as any)?.items || (response.data as any)?.items || (response.body as any)?.items || []
+    const allTools = extractItems<LanguageTool>(response)
 
     // Filter tools to only show those that belong to this specific cluster
     // Uses validation to handle orphaned resources gracefully

--- a/src/app/api/clusters/route.ts
+++ b/src/app/api/clusters/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUser } from '@/lib/user-context'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import { LanguageCluster, LanguageClusterListParams, LanguageClusterFormData } from '@/types/cluster'
+import { LanguageAgent } from '@/types/agent'
 import { safeValidateLanguageCluster } from '@/lib/validation'
 
 const NAMESPACE = process.env.OPERATOR_NAMESPACE || 'language-operator'
@@ -18,8 +19,8 @@ export async function GET(request: NextRequest) {
     const params: LanguageClusterListParams = {
       page: parseInt(url.searchParams.get('page') || '1'),
       limit: parseInt(url.searchParams.get('limit') || '50'),
-      sortBy: (url.searchParams.get('sortBy') as any) || 'name',
-      sortOrder: (url.searchParams.get('sortOrder') as any) || 'asc',
+      sortBy: (url.searchParams.get('sortBy') as LanguageClusterListParams['sortBy']) || 'name',
+      sortOrder: (url.searchParams.get('sortOrder') as LanguageClusterListParams['sortOrder']) || 'asc',
       search: url.searchParams.get('search') || undefined,
       phase: url.searchParams.getAll('phase') || undefined,
       domain: url.searchParams.get('domain') || undefined,
@@ -33,25 +34,8 @@ export async function GET(request: NextRequest) {
       const response = await k8sClient.listLanguageClusters(NAMESPACE)
       
       // Handle different response structures from k8s client
-      // Live K8s mode: { body: { items: [...] } }
-      // Error fallback: { data: { items: [] } }
-      const responseBody = (response as any)?.body
-      const responseData = (response as any)?.data
-      const responseItems = (response as any)?.items
-      
-      if (responseBody?.items && Array.isArray(responseBody.items)) {
-        clusters = responseBody.items
-        console.log(`Found ${clusters.length} clusters from Kubernetes API`)
-      } else if (responseData?.items && Array.isArray(responseData.items)) {
-        clusters = responseData.items
-        console.log(`Found ${clusters.length} clusters from response data`)
-      } else if (responseItems && Array.isArray(responseItems)) {
-        clusters = responseItems
-        console.log(`Found ${clusters.length} clusters from direct items`)
-      } else {
-        console.warn('No clusters array found in response structure:', Object.keys(response))
-        clusters = []
-      }
+      clusters = extractItems<LanguageCluster>(response)
+      console.log(`Found ${clusters.length} clusters from Kubernetes API`)
     } catch (k8sError) {
       console.error('Error fetching clusters from Kubernetes:', k8sError instanceof Error ? k8sError.message : String(k8sError))
       // Graceful degradation - return empty list instead of failing
@@ -83,14 +67,11 @@ export async function GET(request: NextRequest) {
       const agentsResponse = await k8sClient.listLanguageAgents('')
       
       // Handle different response structures from k8s client
-      const allAgents = (agentsResponse as any)?.body?.items || 
-                       (agentsResponse as any)?.data?.items || 
-                       (agentsResponse as any)?.items || 
-                       []
-      
+      const allAgents = extractItems<LanguageAgent>(agentsResponse)
+
       // Group agents by cluster
-      agentCountsByCluster = allAgents.reduce((acc: Record<string, number>, agent: any) => {
-        const clusterRef = agent.spec?.clusterRef
+      agentCountsByCluster = allAgents.reduce((acc: Record<string, number>, agent: LanguageAgent) => {
+        const clusterRef = (agent.spec as Record<string, unknown>)?.clusterRef as string | undefined
         if (clusterRef) {
           acc[clusterRef] = (acc[clusterRef] || 0) + 1
         }

--- a/src/app/api/dashboard/counts/route.ts
+++ b/src/app/api/dashboard/counts/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { k8sClient } from '@/lib/k8s-client'
+import { k8sClient, extractItems } from '@/lib/k8s-client'
 import { getAuthenticatedUser } from '@/lib/user-context'
 
 // GET /api/dashboard/counts - Get global resource counts across all accessible clusters
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest) {
 
     // List all clusters the user can see (cluster-scoped, impersonation filters by RBAC)
     const clustersRes = await client.listLanguageClusters('')
-    const clusters = (clustersRes as any)?.items ?? (clustersRes as any)?.body?.items ?? []
+    const clusters = extractItems(clustersRes)
 
     // List namespaced resources across all namespaces the user can access.
     // Each resource type is cluster-scoped in its listing (no namespace filter) so
@@ -24,8 +24,7 @@ export async function GET(request: NextRequest) {
 
     const extract = (res: PromiseSettledResult<unknown>) => {
       if (res.status === 'rejected') return []
-      const val = res.value as any
-      return val?.items ?? val?.body?.items ?? val?.data?.items ?? []
+      return extractItems(res.value)
     }
 
     return NextResponse.json({

--- a/src/lib/k8s-client.ts
+++ b/src/lib/k8s-client.ts
@@ -1045,3 +1045,23 @@ class KubernetesClient {
 
 // Export singleton instance
 export const k8sClient = KubernetesClient.getInstance()
+
+/** Extract a list from any k8s client response shape (body.items / data.items / items). */
+export function extractItems<T>(response: unknown): T[] {
+  const r = response as Record<string, unknown>
+  return (
+    ((r?.body as Record<string, unknown>)?.items as T[]) ??
+    ((r?.data as Record<string, unknown>)?.items as T[]) ??
+    (r?.items as T[]) ??
+    []
+  )
+}
+
+/** Extract a single resource from any k8s client response shape (body / data / direct). */
+export function extractItem<T>(response: unknown): T | null {
+  const r = response as Record<string, unknown>
+  if (r?.body) return r.body as T
+  if (r?.data) return r.data as T
+  if (r) return r as T
+  return null
+}


### PR DESCRIPTION
## Summary

- Adds `extractItems<T>()` and `extractItem<T>()` generic helpers to `src/lib/k8s-client.ts` to consolidate the three-way k8s response unwrap pattern (`body.items` / `data.items` / `items`)
- Replaces all `as any` / `: any` casts across 27 API route files with properly typed equivalents using `V1Pod`, `V1Container`, `V1ContainerStatus`, `RbacV1Subject`, `CoreV1Event`, and local CRD types
- Removes all `catch (error: any)` occurrences; uses `error instanceof Error` or typed casts where needed
- Updates Jest mocks for `@/lib/k8s-client` in personas and models test files to include `extractItems`/`extractItem` inline implementations

Closes #24

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npm test` passes — 46/46 tests green
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)