### PR TITLE
fix: remove remaining rounded-* corners from layouts, forms, and containers

### DIFF
--- a/src/app/(dashboard)/capacity/page.tsx
+++ b/src/app/(dashboard)/capacity/page.tsx
@@ -103,8 +103,8 @@ function sortRows(rows: CapacityRow[], key: SortKey, dir: 'asc' | 'desc'): Capac
 function PctBar({ pct }: { pct: number }) {
   const color = pct >= 90 ? 'bg-destructive' : pct >= 70 ? 'bg-accent' : 'bg-status-ready-foreground'
   return (
-    <div className="h-1 w-full rounded-full bg-stone-200 dark:bg-stone-700 mt-1">
-      <div className={`h-1 rounded-full ${color}`} style={{ width: `${pct}%` }} />
+    <div className="h-1 w-full bg-stone-200 dark:bg-stone-700 mt-1">
+      <div className={`h-1 ${color}`} style={{ width: `${pct}%` }} />
     </div>
   )
 }

--- a/src/app/(dashboard)/clusters/[name]/agents/[agentName]/layout.tsx
+++ b/src/app/(dashboard)/clusters/[name]/agents/[agentName]/layout.tsx
@@ -254,7 +254,7 @@ export default function AgentDetailLayout({ children }: AgentDetailLayoutProps) 
                 <Spinner size="sm" />
               </div>
             ) : (
-              <div className="border rounded-lg flex-1 min-h-0 flex flex-col">
+              <div className="border flex-1 min-h-0 flex flex-col">
                 <div className="bg-muted p-3 border-b flex justify-between items-center">
                   <span className="font-light text-sm">
                     {agent?.metadata.name || agentName}.yaml

--- a/src/app/(dashboard)/clusters/[name]/edit/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/edit/page.tsx
@@ -317,7 +317,7 @@ export default function EditClusterPage({ params }: { params: Promise<{ name: st
 
                 {/* Error Display */}
                 {activeTab === 'network' && error && (
-                  <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+                  <div className="border border-red-200 bg-red-50 p-4">
                     <p className="text-sm text-red-700">{error}</p>
                   </div>
                 )}

--- a/src/app/(dashboard)/clusters/[name]/models/[modelName]/layout.tsx
+++ b/src/app/(dashboard)/clusters/[name]/models/[modelName]/layout.tsx
@@ -261,7 +261,7 @@ export default function ModelDetailLayout({ children }: ModelDetailLayoutProps) 
                 <Spinner size="sm" />
               </div>
             ) : (
-              <div className="border rounded-lg flex-1 min-h-0 flex flex-col">
+              <div className="border flex-1 min-h-0 flex flex-col">
                 <div className="bg-muted p-3 border-b flex justify-between items-center">
                   <span className="font-light text-sm">
                     {model?.metadata.name || modelName}.yaml

--- a/src/app/(dashboard)/clusters/[name]/personas/[personaName]/edit/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/personas/[personaName]/edit/page.tsx
@@ -102,7 +102,7 @@ export default function EditClusterPersonaPage() {
         {initialData ? (
           <>
             {submitError && (
-              <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-md">
+              <div className="mb-4 p-4 bg-destructive/10 border border-destructive/30">
                 <p className="text-sm text-red-800">{submitError}</p>
               </div>
             )}

--- a/src/app/(dashboard)/clusters/[name]/personas/[personaName]/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/personas/[personaName]/page.tsx
@@ -266,7 +266,7 @@ export default function ClusterPersonaDetailPage() {
                 <Spinner size="sm" />
               </div>
             ) : (
-              <div className="border rounded-lg flex-1 min-h-0 flex flex-col">
+              <div className="border flex-1 min-h-0 flex flex-col">
                 <div className="bg-muted p-3 border-b flex justify-between items-center">
                   <span className="font-light text-sm">
                     {persona?.metadata.name || personaName}.yaml

--- a/src/app/(dashboard)/clusters/[name]/personas/new/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/personas/new/page.tsx
@@ -89,7 +89,7 @@ export default function CreateClusterPersonaPage() {
 
         {/* Form */}
         {error && (
-          <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-md">
+          <div className="mb-4 p-4 bg-red-50 border border-red-200">
             <p className="text-sm text-red-800">{error}</p>
           </div>
         )}

--- a/src/app/(dashboard)/clusters/[name]/tools/[toolName]/layout.tsx
+++ b/src/app/(dashboard)/clusters/[name]/tools/[toolName]/layout.tsx
@@ -240,7 +240,7 @@ export default function ToolDetailLayout({ children }: ToolDetailLayoutProps) {
                 <Spinner size="sm" />
               </div>
             ) : (
-              <div className="border rounded-lg flex-1 min-h-0 flex flex-col">
+              <div className="border flex-1 min-h-0 flex flex-col">
                 <div className="bg-muted p-3 border-b flex justify-between items-center">
                   <span className="font-light text-sm">
                     {tool?.metadata.name || toolName}.yaml

--- a/src/components/agents/agent-logs.tsx
+++ b/src/components/agents/agent-logs.tsx
@@ -170,7 +170,7 @@ export function AgentLogs({ agent, clusterName }: AgentLogsProps) {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center gap-2 text-accent">
-              <div className="animate-pulse w-2 h-2 bg-accent rounded-full" />
+              <div className="animate-pulse w-2 h-2 bg-accent" />
               <span className="text-sm">Streaming logs in real-time</span>
             </div>
           </CardContent>

--- a/src/components/agents/agent-overview.tsx
+++ b/src/components/agents/agent-overview.tsx
@@ -62,7 +62,7 @@ export function AgentOverview({ agent, clusterName }: AgentOverviewProps) {
           <CardTitle>Goal</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="border border-stone-200 dark:border-stone-700 rounded-md overflow-hidden">
+          <div className="border border-stone-200 dark:border-stone-700 overflow-hidden">
             {agent.spec.instructions ? (
               <SyntaxHighlighter
                 language="markdown"

--- a/src/components/forms/enhanced-network-policy-form.tsx
+++ b/src/components/forms/enhanced-network-policy-form.tsx
@@ -223,7 +223,7 @@ export function EnhancedNetworkPolicyForm<T extends FieldValues>({
                 </div>
                 
                 {(!watchedEgressRules || watchedEgressRules.length === 0) ? (
-                  <div className="text-center py-8 text-muted-foreground border-2 border-dashed rounded-lg">
+                  <div className="text-center py-8 text-muted-foreground border-2 border-dashed">
                     <ArrowRight className="h-8 w-8 mx-auto mb-2 opacity-50" />
                     <p>No egress rules configured</p>
                     <p className="text-sm">External access is blocked by default</p>
@@ -394,7 +394,7 @@ export function EnhancedNetworkPolicyForm<T extends FieldValues>({
                 </div>
                 
                 {(!watchedIngressRules || watchedIngressRules.length === 0) ? (
-                  <div className="text-center py-8 text-muted-foreground border-2 border-dashed rounded-lg">
+                  <div className="text-center py-8 text-muted-foreground border-2 border-dashed">
                     <ArrowLeft className="h-8 w-8 mx-auto mb-2 opacity-50" />
                     <p>No ingress rules configured</p>
                     <p className="text-sm">Inbound access is determined by default policies</p>
@@ -582,7 +582,7 @@ export function EnhancedNetworkPolicyForm<T extends FieldValues>({
               </div>
               
               {(!watchedEgressRules || watchedEgressRules.length === 0) ? (
-                <div className="text-center py-8 text-muted-foreground border-2 border-dashed rounded-lg">
+                <div className="text-center py-8 text-muted-foreground border-2 border-dashed">
                   <Network className="h-8 w-8 mx-auto mb-2 opacity-50" />
                   <p>No egress rules configured</p>
                   <p className="text-sm">External access is blocked by default</p>

--- a/src/components/forms/persona-form.tsx
+++ b/src/components/forms/persona-form.tsx
@@ -980,7 +980,7 @@ export function PersonaForm({
         </CardHeader>
         <CardContent className="space-y-4">
           {formData.examples.map((example, index) => (
-            <div key={index} className="space-y-3 p-4 border rounded-lg">
+            <div key={index} className="space-y-3 p-4 border">
               <div className="flex items-center justify-between">
                 <Label>Example {index + 1}</Label>
                 {formData.examples.length > 1 && (
@@ -1069,7 +1069,7 @@ export function PersonaForm({
         </CardHeader>
         <CardContent className="space-y-4">
           {formData.knowledgeSources.map((source, index) => (
-            <div key={index} className="space-y-3 p-4 border rounded-lg">
+            <div key={index} className="space-y-3 p-4 border">
               <div className="flex items-center justify-between">
                 <Label>Knowledge Source {index + 1}</Label>
                 <Button
@@ -1325,7 +1325,7 @@ export function PersonaForm({
         </CardHeader>
         <CardContent className="space-y-4">
           {formData.rules.map((rule, index) => (
-            <div key={index} className="space-y-3 p-4 border rounded-lg">
+            <div key={index} className="space-y-3 p-4 border">
               <div className="flex items-center justify-between">
                 <Label>Rule {index + 1}</Label>
                 <Button

--- a/src/components/forms/tool-edit-form.tsx
+++ b/src/components/forms/tool-edit-form.tsx
@@ -456,7 +456,7 @@ export function ToolEditForm({
                 </div>
 
                 {(formData.egress || []).length === 0 ? (
-                  <div className="text-center py-8 text-muted-foreground border-2 border-dashed rounded-lg">
+                  <div className="text-center py-8 text-muted-foreground border-2 border-dashed">
                     <Network className="h-8 w-8 mx-auto mb-2 opacity-50" />
                     <p>No egress rules configured</p>
                     <p className="text-sm">Click "Add Rule" to configure external access</p>


### PR DESCRIPTION
Closes #19

Removes all `rounded-*` class violations identified in the PR #30 review comment that were not addressed at the time.

**13 files changed across 6 categories:**
- Panel containers (agent/model/tool/persona YAML modal wrappers) — remove `rounded-lg`
- Error boxes (personas edit/new, cluster edit) — remove `rounded-md`/`rounded-lg`; also fix off-palette `bg-red-50`/`border-red-200` → `bg-destructive/10`/`border-destructive/30` in personas edit
- Progress bar track and fill in capacity page — remove `rounded-full`
- Status pulse dot in agent-logs — remove `rounded-full`
- Dashed drop zones in tool-edit-form and enhanced-network-policy-form — remove `rounded-lg`
- Rule/knowledge section cards in persona-form — remove `rounded-lg`
- Goal container in agent-overview — remove `rounded-md`