### PR TITLE
fix: replace remaining inline empty states with EmptyState component

### DIFF
--- a/src/app/(dashboard)/capacity/page.tsx
+++ b/src/app/(dashboard)/capacity/page.tsx
@@ -13,6 +13,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Server, ChevronUp, ChevronDown, ChevronsUpDown } from 'lucide-react'
+import { EmptyState } from '@/components/ui/empty-state'
 import { useClusters } from '@/hooks/use-clusters'
 import { LanguageCluster, ClusterCapacitySpec, ClusterCapacityStatus } from '@/types/cluster'
 
@@ -216,8 +217,8 @@ export default function CapacityPage() {
               <TableBody>
                 {rows.length === 0 && (
                   <TableRow>
-                    <TableCell colSpan={7} className="text-center text-muted-foreground py-12">
-                      No clusters found.
+                    <TableCell colSpan={7}>
+                      <EmptyState icon={Server} title="No clusters found" className="py-8" />
                     </TableCell>
                   </TableRow>
                 )}

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -13,6 +13,7 @@ import { useAggregatedAgents } from '@/hooks/use-aggregated-agents'
 import { LanguageCluster } from '@/types/cluster'
 import { LanguageAgent } from '@/types/agent'
 import { ClusterStatusBadge, AgentStatusBadge } from '@/components/ui/resource-status-badge'
+import { EmptyState } from '@/components/ui/empty-state'
 import { useRouter } from 'next/navigation'
 
 type QuickActionType = 'agent' | 'model' | 'tool'
@@ -211,11 +212,12 @@ export default function OrganizationDashboard() {
                 <p className="text-sm text-stone-600 dark:text-stone-400">Failed to load clusters</p>
               </div>
             ) : !clustersData?.data || clustersData.data.length === 0 ? (
-              <div className="text-center py-4">
-                <Boxes className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
-                <p className="text-sm text-stone-600 dark:text-stone-400">No clusters deployed</p>
-                <p className="text-xs text-stone-500 dark:text-stone-500 mt-1">Deploy your first cluster to get started</p>
-              </div>
+              <EmptyState
+                icon={Boxes}
+                title="No clusters deployed"
+                description="Deploy your first cluster to get started"
+                className="py-4"
+              />
             ) : (
               <div className="space-y-3">
                 {clustersData.data.slice(0, 5).map((cluster: LanguageCluster) => (
@@ -295,11 +297,12 @@ export default function OrganizationDashboard() {
                 <p className="text-sm text-stone-600 dark:text-stone-400">Failed to load agents</p>
               </div>
             ) : !agentsData?.data || agentsData.data.length === 0 ? (
-              <div className="text-center py-4">
-                <Bot className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
-                <p className="text-sm text-stone-600 dark:text-stone-400">No agents deployed</p>
-                <p className="text-xs text-stone-500 dark:text-stone-500 mt-1">Create your first agent to get started</p>
-              </div>
+              <EmptyState
+                icon={Bot}
+                title="No agents deployed"
+                description="Create your first agent to get started"
+                className="py-4"
+              />
             ) : (
               <div className="space-y-3">
                 {agentsData.data.slice(0, 5).map((agent: LanguageAgent) => (


### PR DESCRIPTION
Closes #42

Finishes the work started in #49. Replaces the two inline empty-state patterns that were flagged in the issue review:

- `capacity/page.tsx` — table empty row now uses `<EmptyState icon={Server} title="No clusters found" className="py-8" />` inside `<TableCell colSpan={7}>`
- `page.tsx` (dashboard home) — both compact sidebar widgets (clusters + agents) now use `<EmptyState className="py-4">` instead of hand-rolled `div + icon + <p>` markup