### PR TITLE
fix: surface 403 RBAC error on clusters page instead of silent empty state

### DIFF
--- a/src/app/(dashboard)/clusters/page.tsx
+++ b/src/app/(dashboard)/clusters/page.tsx
@@ -236,7 +236,7 @@ export default function ClustersPage() {
             <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
             <h3 className="text-lg font-light mb-2">Failed to load clusters</h3>
             <p className="text-muted-foreground mb-4">
-              There was an error loading your language clusters.
+              {error.message}
             </p>
             <Button onClick={() => refetch()}>
               Try Again

--- a/src/app/api/clusters/route.ts
+++ b/src/app/api/clusters/route.ts
@@ -39,6 +39,13 @@ export async function GET(request: NextRequest) {
       console.log(`Found ${clusters.length} clusters from Kubernetes API`)
     } catch (k8sError) {
       console.error('Error fetching clusters from Kubernetes:', k8sError instanceof Error ? k8sError.message : String(k8sError))
+      const statusCode = (k8sError as { response?: { statusCode?: number } })?.response?.statusCode
+      if (statusCode === 403) {
+        return NextResponse.json(
+          { error: 'Permission denied: check RBAC configuration (langop-admin ClusterRole may be missing)' },
+          { status: 403 }
+        )
+      }
       // Graceful degradation - return empty list instead of failing
       clusters = []
     }

--- a/src/hooks/use-clusters.ts
+++ b/src/hooks/use-clusters.ts
@@ -17,7 +17,8 @@ export function useClusters(params?: LanguageClusterListParams) {
 
       const response = await fetch(`/api/clusters?${searchParams}`)
       if (!response.ok) {
-        throw new Error('Failed to fetch clusters')
+        const body = await response.json().catch(() => ({}))
+        throw new Error((body as { error?: string }).error || 'Failed to fetch clusters')
       }
       return response.json()
     },


### PR DESCRIPTION
Closes #53