### PR TITLE
fix: show cluster name as resource namespace in cluster detail

### DIFF
--- a/src/app/(dashboard)/clusters/[name]/page.tsx
+++ b/src/app/(dashboard)/clusters/[name]/page.tsx
@@ -123,8 +123,8 @@ export default function ClusterDashboard() {
                 </div>
               )}
               <div>
-                <dt className="text-sm font-light text-stone-600 dark:text-stone-400">Namespace</dt>
-                <dd className="mt-1 text-sm text-stone-900 dark:text-stone-300">{cluster.metadata?.namespace}</dd>
+                <dt className="text-sm font-light text-stone-600 dark:text-stone-400">Resource Namespace</dt>
+                <dd className="mt-1 text-sm text-stone-900 dark:text-stone-300">{cluster.metadata?.name}</dd>
               </div>
               <div>
                 <dt className="text-sm font-light text-stone-600 dark:text-stone-400">Status</dt>

--- a/src/app/api/clusters/[name]/__tests__/route.test.ts
+++ b/src/app/api/clusters/[name]/__tests__/route.test.ts
@@ -81,7 +81,7 @@ describe('GET /api/clusters/[name]', () => {
     mockGetToken.mockResolvedValue(AUTHED_TOKEN as any)
   })
 
-  it('returns the cluster with namespace injected', async () => {
+  it('returns the cluster', async () => {
     mockK8s.getLanguageCluster.mockResolvedValue(makeCluster('my-cluster'))
 
     const res = await GET(makeRequest(), makeParams())
@@ -89,27 +89,26 @@ describe('GET /api/clusters/[name]', () => {
 
     expect(res.status).toBe(200)
     expect(body.cluster.metadata.name).toBe('my-cluster')
-    expect(body.cluster.metadata.namespace).toBe('language-operator')
   })
 
-  it('handles body-wrapped k8s response and injects namespace', async () => {
+  it('handles body-wrapped k8s response', async () => {
     mockK8s.getLanguageCluster.mockResolvedValue({ body: makeCluster('my-cluster') })
 
     const res = await GET(makeRequest(), makeParams())
     const body = await res.json()
 
     expect(res.status).toBe(200)
-    expect(body.cluster.metadata.namespace).toBe('language-operator')
+    expect(body.cluster.metadata.name).toBe('my-cluster')
   })
 
-  it('handles data-wrapped k8s response and injects namespace', async () => {
+  it('handles data-wrapped k8s response', async () => {
     mockK8s.getLanguageCluster.mockResolvedValue({ data: makeCluster('my-cluster') })
 
     const res = await GET(makeRequest(), makeParams())
     const body = await res.json()
 
     expect(res.status).toBe(200)
-    expect(body.cluster.metadata.namespace).toBe('language-operator')
+    expect(body.cluster.metadata.name).toBe('my-cluster')
   })
 
   it('returns 404 when cluster not found', async () => {

--- a/src/app/api/clusters/[name]/route.ts
+++ b/src/app/api/clusters/[name]/route.ts
@@ -72,10 +72,6 @@ export async function GET(
       return NextResponse.json({ error: 'Cluster not found' }, { status: 404 })
     }
 
-    // LanguageCluster is cluster-scoped; K8s strips metadata.namespace.
-    // Inject the operator namespace so the UI can display it.
-    cluster.metadata = { ...cluster.metadata, namespace: NAMESPACE }
-
     return NextResponse.json({ cluster })
   } catch (error) {
     const k8sStatus = extractK8sStatusCode(error)


### PR DESCRIPTION
Closes #64

The previous fix (#66) injected `OPERATOR_NAMESPACE` (`language-operator`) into `metadata.namespace`, which is misleading — that's where the LanguageCluster CRD lives, not where users find their agents.

Per CLAUDE.md, sub-resources (agents, models, tools, personas) live in a namespace named after their cluster. This fix:
- Removes the wrong namespace injection from the GET handler
- Changes the UI label to **Resource Namespace** and renders `cluster.metadata.name` (the cluster name), since that is the namespace where all sub-resources live