### PR TITLE
fix: disable React Query retry on access bindings fetch to eliminate 7s delay

### DIFF
--- a/src/hooks/use-access.ts
+++ b/src/hooks/use-access.ts
@@ -16,6 +16,7 @@ export function useAccess(clusterName: string) {
       return response.json() as Promise<{ success: boolean; data: AccessBinding[] }>
     },
     enabled: !!clusterName,
+    retry: false,
   })
 }
 


### PR DESCRIPTION
Closes #71